### PR TITLE
Update code to work with Drishti v0.8

### DIFF
--- a/explorer/plots/operation.py
+++ b/explorer/plots/operation.py
@@ -883,9 +883,7 @@ else:
     size = 176
 
 file = options["file1"].split(".darshan")[0]
-command = "drishti --html --light --size {} --json {} {}.darshan".format(
-    size, json_file_path, file
-)
+command = f"drishti --html --light --size {size} --export_dir {os.path.dirname(file)} --json {json_file_path} {file}.darshan"
 args = shlex.split(command)
 s = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 sOutput, sError = s.communicate()
@@ -901,10 +899,10 @@ if s.returncode == 0:
     with open(options["output"], "r") as html_file:
         output_doc.body.extend(BeautifulSoup(html_file.read(), "html.parser").body)
 
-    with open(file + ".darshan.html", "r") as html_file:
+    with open(file + ".html", "r") as html_file:
         output_doc.head.extend(BeautifulSoup(html_file.read(), "html.parser").head)
 
-    with open(file + ".darshan.html", "r") as html_file:
+    with open(file + ".html", "r") as html_file:
         output_doc.body.extend(BeautifulSoup(html_file.read(), "html.parser").body)
 
     output_doc.style.append(BeautifulSoup("pre { padding-left: 60px;}", "html.parser"))

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ pyranges>=0.0.120
 darshan
 pyarrow>=10.0.1
 bs4>=0.0.1
-drishti-io>=0.5
+drishti-io>=0.8


### PR DESCRIPTION
This PR updates dxt-explorer to continue working with Drishti v0.8

Drishti has breaking changes due to https://github.com/hpc-io/drishti-io/pull/16/files

The PR in Drishti will be included in [Drishti v0.8](https://github.com/hpc-io/drishti-io/milestone/3)