### PR TITLE
fix: guard DXT_POSIX and DXT_MPIIO access with existence checks in subset_dataset

### DIFF
--- a/explorer/dxt.py
+++ b/explorer/dxt.py
@@ -368,18 +368,20 @@ class Explorer:
                 except Exception:
                     pass
 
-            list(
-                map(
-                    lambda rec: graceful_wrapper(report, rec, lustre_records_by_id),
-                    report.records["DXT_POSIX"],
+            if "DXT_POSIX" in report.records:
+                list(
+                    map(
+                        lambda rec: graceful_wrapper(report, rec, lustre_records_by_id),
+                        report.records["DXT_POSIX"],
+                    )
                 )
-            )
-            list(
-                map(
-                    lambda rec: graceful_wrapper(report, rec, lustre_records_by_id),
-                    report.records["DXT_MPIIO"],
+            if "DXT_MPIIO" in report.records:
+                list(
+                    map(
+                        lambda rec: graceful_wrapper(report, rec, lustre_records_by_id),
+                        report.records["DXT_MPIIO"],
+                    )
                 )
-            )
 
         df_posix = []
         if "DXT_POSIX" in report.records:


### PR DESCRIPTION
Fixes #25

**Problem:** `KeyError: 'DXT_MPIIO'` crash when running dxt-explorer on traces from POSIX-only applications (e.g. AI/ML workloads) that have no MPI-IO records. The `report.records["DXT_MPIIO"]` key was accessed unconditionally inside the `lustre_records_by_id` block in `subset_dataset()`.

**Fix:** Added `if "DXT_POSIX" in report.records` and `if "DXT_MPIIO" in report.records` guards, consistent with the same checks already present a few lines below in the same function.